### PR TITLE
Expose `File` class globally

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -4,6 +4,7 @@ unreleased:
   new features:
     - GH-1032 Enhanced performance when operating on buffers in Node environment
     - GH-1035 Added missing buffer APIs to expose a uniform interface across environments
+    - GH-1051 Exposed `File` globally
 
 5.1.1:
   date: 2024-08-01

--- a/lib/sandbox/execute-context.js
+++ b/lib/sandbox/execute-context.js
@@ -25,6 +25,8 @@ module.exports = function (scope, code, execution, console, timers, pmapi, onAss
     // prepare the scope's environment variables
     scope.import({
         Buffer: require('buffer').Buffer,
+        // TODO: Remove this once it is added to Uniscope (node>=v20)
+        File: require('buffer').File,
         // forward console
         console: console,
         // forward pm-api instance

--- a/test/unit/sandbox-libraries/buffer.test.js
+++ b/test/unit/sandbox-libraries/buffer.test.js
@@ -262,12 +262,28 @@ describe('sandbox library - buffer', function () {
         `, done);
     });
 
+    it('should have same File implementation as global', function (done) {
+        context.execute(`
+            const assert = require('assert'),
+                bufferFile = require('buffer').File;
+            assert.strictEqual(File === bufferFile, true);
+        `, done);
+    });
+
     it('should expose Blob class', function (done) {
         context.execute(`
             const assert = require('assert'),
                 buffer = require('buffer');
             const blob = new buffer.Blob(['hello world'], { type: 'text/plain' });
             assert.strictEqual(blob.size, 11);
+        `, done);
+    });
+
+    it('should have same Blob implementation as global', function (done) {
+        context.execute(`
+            const assert = require('assert'),
+                bufferBlob = require('buffer').Blob;
+            assert.strictEqual(Blob === bufferBlob, true);
         `, done);
     });
 });


### PR DESCRIPTION
## Context

File exists as global only on node v20 or above, while it is available on the Web already.

## Changes

We already have File exposed via the buffer module. So to provide consistent behavior across node and web, made `File` explicitly available using scope libs of Uniscope