### PR TITLE
Exposed missing buffer globals for compatibility

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,6 +3,7 @@ unreleased:
     - GH-1032 Add support for configuring module resolver based on environment
   new features:
     - GH-1032 Enhanced performance when operating on buffers in Node environment
+    - GH-1035 Added missing buffer APIs to expose a uniform interface across environments
 
 5.1.1:
   date: 2024-08-01

--- a/lib/vendor/buffer/buffer.js
+++ b/lib/vendor/buffer/buffer.js
@@ -1,9 +1,21 @@
+const NOT_IMPLEMENTED = function () {
+    throw new Error('Not implemented');
+};
+
 function getBufferModule (buffer) {
     return  {
         Buffer: buffer.Buffer,
         SlowBuffer: buffer.SlowBuffer,
         INSPECT_MAX_BYTES: buffer.INSPECT_MAX_BYTES,
-        kMaxLength: buffer.kMaxLength
+        kMaxLength: buffer.kMaxLength,
+        kStringMaxLength: buffer.kStringMaxLength,
+        constants: buffer.constants,
+        File: buffer.File,
+        Blob: buffer.Blob,
+        isAscii: NOT_IMPLEMENTED,
+        isUtf8: NOT_IMPLEMENTED,
+        resolveObjectURL: NOT_IMPLEMENTED,
+        transcode: NOT_IMPLEMENTED
     }
 }
 

--- a/lib/vendor/buffer/index.browser.js
+++ b/lib/vendor/buffer/index.browser.js
@@ -2,7 +2,18 @@ const getBufferModule = require('./buffer');
 const SpecificBuffer = require('./specific-buffer');
 const buffer = require('buffer/');
 
+// Using 32-bit implementation value from Node
+// https://github.com/nodejs/node/blob/main/deps/v8/include/v8-primitive.h#L126
+const K_STRING_MAX_LENGTH = (1 << 28) - 16;
+
 module.exports = getBufferModule({
     ...buffer,
-    Buffer: SpecificBuffer(buffer.Buffer)
-})
+    Buffer: SpecificBuffer(buffer.Buffer),
+    kStringMaxLength: K_STRING_MAX_LENGTH,
+    constants: {
+        MAX_LENGTH: buffer.kMaxLength,
+        MAX_STRING_LENGTH: K_STRING_MAX_LENGTH
+    },
+    File: File,
+    Blob: Blob
+});

--- a/lib/vendor/buffer/specific-buffer.js
+++ b/lib/vendor/buffer/specific-buffer.js
@@ -1,3 +1,7 @@
+const NOT_IMPLEMENTED = function () {
+    throw new Error('Not implemented');
+};
+
 function SpecificBuffer (_Buffer) {
     const Buffer = function () {
         if (typeof arguments[0] === 'number') {
@@ -50,6 +54,10 @@ function SpecificBuffer (_Buffer) {
     Buffer.byteLength = function () {
         return _Buffer.byteLength(...arguments);
     };
+
+    Buffer.copyBytesFrom = NOT_IMPLEMENTED;
+
+    Buffer.of = NOT_IMPLEMENTED;
 
     return Buffer;
 }

--- a/test/unit/sandbox-libraries/buffer.test.js
+++ b/test/unit/sandbox-libraries/buffer.test.js
@@ -243,8 +243,31 @@ describe('sandbox library - buffer', function () {
                 buffer = require('buffer');
 
             assert.strictEqual(typeof buffer.kMaxLength, 'number');
+            assert.strictEqual(typeof buffer.kStringMaxLength, 'number');
+            assert.strictEqual(typeof buffer.constants.MAX_LENGTH, 'number');
+            assert.strictEqual(typeof buffer.constants.MAX_STRING_LENGTH, 'number');
             assert.strictEqual(typeof buffer.INSPECT_MAX_BYTES, 'number');
 
+        `, done);
+    });
+
+    it('should expose File class', function (done) {
+        context.execute(`
+            const assert = require('assert'),
+                buffer = require('buffer');
+            const lastModified = Date.now();
+            const file = new buffer.File([], 'filename.txt', { type: 'text/plain', lastModified });
+            assert.strictEqual(file.name, 'filename.txt');
+            assert.strictEqual(file.lastModified, lastModified);
+        `, done);
+    });
+
+    it('should expose Blob class', function (done) {
+        context.execute(`
+            const assert = require('assert'),
+                buffer = require('buffer');
+            const blob = new buffer.Blob(['hello world'], { type: 'text/plain' });
+            assert.strictEqual(blob.size, 11);
         `, done);
     });
 });


### PR DESCRIPTION
Exposed the following buffer globals to provide a uniform interface on the browser and node environment:

- [buffer.Blob](https://nodejs.org/api/buffer.html#class-blob)
- [buffer.File](https://nodejs.org/api/buffer.html#class-file) (available since node v18.13, will require us to drop support for v16)
- [buffer. kStringMaxLength](https://nodejs.org/api/buffer.html#bufferkstringmaxlength)
- [Buffer constants](https://nodejs.org/api/buffer.html#buffer-constants)