### PR TITLE
Add support for pm.connection and pm.message

### DIFF
--- a/lib/sandbox/execute.js
+++ b/lib/sandbox/execute.js
@@ -138,6 +138,16 @@ module.exports = function (bridge, glob) {
 
                 bridge.dispatch(assertionEventName, options.cursor, assertions);
                 bridge.dispatch(EXECUTION_ASSERTION_EVENT, options.cursor, assertions);
+            },
+
+            // TODO: Handle timers
+            dispatchConnectionEvents = {
+                sendMessage (...args) {
+                    bridge.dispatch('connection.sendMessage.' + id, ...args);
+                },
+                close (...args) {
+                    bridge.dispatch('connection.close.' + id, ...args);
+                }
             };
 
         let waiting,
@@ -214,7 +224,8 @@ module.exports = function (bridge, glob) {
                     var eventId = timers.setEvent(callback);
 
                     bridge.dispatch(executionRequestEventName, options.cursor, id, eventId, request);
-                }, dispatchAssertions, new PostmanCookieStore(id, bridge, timers), {
+                }, dispatchAssertions, dispatchConnectionEvents,
+                new PostmanCookieStore(id, bridge, timers), {
                     disabledAPIs: initializationOptions.disabledAPIs
                 })
             ),

--- a/lib/sandbox/execution.js
+++ b/lib/sandbox/execution.js
@@ -42,10 +42,11 @@ class Execution {
         });
 
         if (options.initializeExecution) {
-            const { request, response } = options.initializeExecution(this.target, context) || {};
+            const { request, response, message } = options.initializeExecution(this.target, context) || {};
 
             this.request = request;
             this.response = response;
+            this.message = message;
         }
         else {
             if (TARGETS_WITH_REQUEST[this.target] || _.has(context, PROPERTY.REQUEST)) {

--- a/lib/sandbox/pmapi.js
+++ b/lib/sandbox/pmapi.js
@@ -45,11 +45,12 @@ const _ = require('lodash'),
  * @param {Execution} execution -
  * @param {Function} onRequest -
  * @param {Function} onAssertion -
+ * @param {Object} onConnection -
  * @param {Object} cookieStore -
  * @param {Object} [options] -
  * @param {Array.<String>} [options.disabledAPIs] -
  */
-function Postman (execution, onRequest, onAssertion, cookieStore, options = {}) {
+function Postman (execution, onRequest, onAssertion, onConnection, cookieStore, options = {}) {
     // @todo - ensure runtime passes data in a scope format
     let iterationData = new VariableScope();
 
@@ -167,6 +168,8 @@ function Postman (execution, onRequest, onAssertion, cookieStore, options = {}) 
          */
         response: execution.response,
 
+        message: execution.message,
+
         /**
          * The cookies object contains a list of cookies that are associated with the domain
          * to which the request was made.
@@ -250,7 +253,9 @@ function Postman (execution, onRequest, onAssertion, cookieStore, options = {}) 
             });
 
             return self;
-        }
+        },
+
+        connection: onConnection
     }, options.disabledAPIs);
 
     // extend pm api with test runner abilities
@@ -265,6 +270,16 @@ function Postman (execution, onRequest, onAssertion, cookieStore, options = {}) 
             }
         });
     }
+
+    if (this.message) {
+        // these are removed before serializing see `purse.js`
+        Object.defineProperty(this.message, 'to', {
+            get () {
+                return chai.expect(this).to;
+            }
+        });
+    }
+
     // add request assertions
     if (this.request) {
         // these are removed before serializing see `purse.js`


### PR DESCRIPTION
Introduces three new pm APIs in the sandbox:

- `pm.message`:  Can be used to provide access to a specific message in the context of the current script.
- `pm.connection.sendMessage` - Can be used to support sending messages in streaming requests.
- `pm.connection.close` - Can be used to close an active connection with a server.